### PR TITLE
絵文字の表記ゆれ対応

### DIFF
--- a/attendance_slack/plugins.py
+++ b/attendance_slack/plugins.py
@@ -26,7 +26,7 @@ def ronrishusha(message):
     _shukkin(message)
 
 
-@respond_to(":buturishusha:")
+@respond_to(":buts?urishusha:")
 def buturishusha(message):
     _shukkin(message)
 
@@ -51,7 +51,7 @@ def ronritaisha(message):
     _taikin(message)
 
 
-@respond_to(":buturitaisha:")
+@respond_to(":buts?uritaisha:")
 def buturitaisha(message):
     _taikin(message)
 


### PR DESCRIPTION
物理{出社,退社}の「つ」を

- tu
- tsu

それぞれ表現で別の絵文字が登録されているため、どちらにも対応できるように正規表現を修正しました